### PR TITLE
Fix modification of mutable default value

### DIFF
--- a/kinto/schema_validation.py
+++ b/kinto/schema_validation.py
@@ -68,7 +68,9 @@ def validate(data, schema):
     return _schema_cache[cache_key].validate(data)
 
 
-def validate_schema(data, schema, id_field, ignore_fields=[]):
+def validate_schema(data, schema, id_field, ignore_fields=None):
+    if ignore_fields is None:
+        ignore_fields = []
     # Only ignore the `id` field if the schema does not explicitly mention it.
     if id_field not in schema.get("properties", {}):
         ignore_fields += (id_field,)


### PR DESCRIPTION
Hi,

I came across what I think is a bug when looking at the alerts for this project on LGTM.com (full disclosure: I work on the Python analysis there).

Essentially, default parameter values in Python are shared between all invocations of a function. This means that if a default value is mutable, and if it is modified inside the function, then that modification will be in effect the next time the function is called, and this is rarely what we want. 

In this particular case, the default value for `ignore_fields` will contain all of the `id_fields` encountered so far, and I'm guessing this is not the intended behaviour.

(If I'm mistaken, please do let me know! We're always interested in improving our analysis and eliminating false positives.)

You can see the original alert on LGTM.com here: https://lgtm.com/projects/g/Kinto/kinto/alerts/?mode=tree&ruleFocus=4840097

Cheers,
    Taus

(I will leave these bits below unfilled until you've determined whether this is actually a bug fix or not...)

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
